### PR TITLE
Stop ignoring views implicitly and instead enabling ignoring files via options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var path = require('path');
 var fs = require('fs');
 var browserify = require('browserify');
 var watchify = require('watchify');

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var path = require('path')
+var path = require('path');
+var fs = require('fs');
 var browserify = require('browserify');
 var watchify = require('watchify');
 var uglify = require('uglify-js');
@@ -39,6 +40,12 @@ function bundle(file, options, cb) {
     });
 
     var ignore = (options.ignore == null) ? [] : options.ignore
+    // Chokidar/watchify provide the realpath's of files as their ids, so we
+    //  add any realpath values that don't match the provided filepath's.
+    ignore.forEach(function(filepath) {
+      var realpath = fs.realpathSync(filepath);
+      if (realpath !== filepath) ignore.push(realpath);
+    });
     matchIgnorePaths = anymatch(ignore)
     // This gets fired every time a dependent file is changed
     w.on('update', function(ids) {

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function bundle(file, options, cb) {
       var realpath = fs.realpathSync(filepath);
       if (realpath !== filepath) ignore.push(realpath);
     });
-    matchIgnorePaths = anymatch(ignore)
+    var matchIgnorePaths = anymatch(ignore)
     // This gets fired every time a dependent file is changed
     w.on('update', function(ids) {
       console.log('Files changed:', ids.toString());

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ function bundle(file, options, cb) {
   options || (options = {});
   options.debug = true;
   var minify = (options.minify == null) ? util.isProduction : options.minify;
+  var ignore = (options.ignore == null) ? [] : options.ignore
   // These objects need to be defined otherwise watchify disables its cache
   options.cache = {};
   options.packageCache = {};
@@ -29,8 +30,6 @@ function bundle(file, options, cb) {
   if (options.onRebundle) {
     var w = watchify(b, {
       delay: 100,
-      // Ignore derby views since they are updated seperately
-      ignoreWatch: '**/derby/lib/*_views.js'
     });
 
     w.on('log', function (msg) {
@@ -40,6 +39,7 @@ function bundle(file, options, cb) {
     // This gets fired everytime a dependent file is changed
     w.on('update', function(ids) {
       console.log('Files changed:', ids.toString());
+      if (isSubset(ids , ignore)) return console.log('Ignoring update');
       callBundle(this, minify, options.onRebundle);
     });
 
@@ -73,4 +73,13 @@ function callBundle(b, minify, cb) {
     var map = JSON.stringify(mapObject);
     cb(null, result.code, map);
   });
+}
+
+// returns true if all elements in array1 exist in array2
+function isSubsetl(array1, array2) {
+  if (!Array.isArray(array1) || !Array.isArray(array2)) return false;
+  var isEqual = array1.every(function(element) {
+    return array2.indexOf(element) > -1
+  });
+  return isEqual;
 }

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function callBundle(b, minify, cb) {
 }
 
 // returns true if all elements in array1 exist in array2
-function isSubsetl(array1, array2) {
+function isSubset(array1, array2) {
   if (!Array.isArray(array1) || !Array.isArray(array2)) return false;
   var isEqual = array1.every(function(element) {
     return array2.indexOf(element) > -1

--- a/index.js
+++ b/index.js
@@ -78,13 +78,22 @@ function callBundle(b, minify, cb) {
     var result = uglify.minify(source, {
       fromString: true,
       outSourceMap: 'map',
-      inSourceMap: inSourceMap
+      inSourceMap: inSourceMap,
+      compress: false
     });
-    // Uglify doesn't include the source content in the map, so copy over from
-    // the map that browserify generates
+
     var mapObject = JSON.parse(result.map);
-    mapObject.sourcesContent = inSourceMap.sourcesContent;
+    // Uglify doesn't include the source content in the map, so copy over from
+    // the map that browserify generates. However, before doing this, we must
+    // first remove any empty sourceContent items since UglifyJS ignores those
+    // files when populating the outSourceMap.sources array.
+    mapObject.sourcesContent = inSourceMap.sourcesContent.filter(isNotEmptyString)
+    if (mapObject.sources.length != mapObject.sourcesContent.length) {
+      console.error('Invalid sourcemap detected. sources.length does not match sourcesContent.length')
+    }
     var map = JSON.stringify(mapObject);
     cb(null, result.code, map);
   });
 }
+
+function isNotEmptyString(str) { return str !== '' }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/derbyjs/racer-bundle/issues"
   },
   "dependencies": {
+    "anymatch": "^1.3.0",
     "browserify": "^12.0.1",
     "convert-source-map": "^1.1.1",
     "uglify-js": "^2.4.24",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "anymatch": "^1.3.0",
-    "browserify": "^12.0.1",
+    "browserify": "^13.0.1",
     "convert-source-map": "^1.1.1",
     "uglify-js": "^2.4.24",
     "watchify": "^3.4.0"


### PR DESCRIPTION
This removes the leaky abstraction where we were explicitly ignoring derby view files and also resolves a bug where users would end up with stale templates when using watchify and editing a coffeescript file after editing a view file.