### PR TITLE
Remove obsolete sourceMappingURL from code after minify

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,10 @@ function callBundle(b, minify, cb) {
     var mapObject = JSON.parse(result.map);
     mapObject.sourcesContent = inSourceMap.sourcesContent;
     var map = JSON.stringify(mapObject);
+
+    // Uglify appends the sourceMappingURL to the end of the result.code
+    // but it does not actually point to anything useful so we can remove it
+    result.code = result.code.replace(/\n\/\/#\ssourceMappingURL=map/, '');
     cb(null, result.code, map);
   });
 }


### PR DESCRIPTION
cc: @nateps @distracteddev 
The sourceMappingURL provided by this bundler is essentially useless as it doesn't point to the right file and causes the sourceMappingURL to be duplicated further in the process by Derby which adds the right file path. This was causing some browser developer tools and exception tracking services to not work properly because of the duplicate entries.

The replace pattern follows the same convention as how the sourceMappingURL is generated in the first place:
https://github.com/mishoo/UglifyJS2/blob/7691bebea525e96cb74d52e0bb8f294cf778c966/bin/uglifyjs#L470