### PR TITLE
Use a persistent module cache with watchify

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function callBundle(b, cachePath, minify, cb) {
     // files when populating the outSourceMap.sources array.
     mapObject.sourcesContent = inSourceMap.sourcesContent.filter(isNotEmptyString)
     if (mapObject.sources.length != mapObject.sourcesContent.length) {
-      console.error('Invalid sourcemap detected. sources.length does not match sourcesContent.length')
+      console.error('[racer-bundle] Invalid sourcemap detected. sources.length does not match sourcesContent.length')
     }
     var map = JSON.stringify(mapObject);
     cb(null, result.code, map);
@@ -146,8 +146,10 @@ function addRealPaths(filePaths) {
     // NOTE: Chokidar provides the realpath's of files as their ids, so we
     // have to add any realpath values that don't match the provided filepath's
     // to our ignore array
-    var realpath = fs.realpathSync(filepath);
-    if (realpath !== filepath) filePaths.push(realpath);
+    if (fs.existsSync(filepath)) {
+      var realpath = fs.realpathSync(filepath);
+      if (realpath !== filepath) filePaths.push(realpath);
+    }
   });
   return filePaths
 }
@@ -160,15 +162,15 @@ function clearCacheFiles(entryFileHash) {
 
 function getModuleCache(entryFileHash) {
   console.log('[racer-bundle] Loading watchify cache')
-  watchify.getCache(getModuleCachePath(entryFileHash))
+  return watchify.getCache(getModuleCachePath(entryFileHash))
 }
 
 function getModuleCachePath(entryFileHash) {
-  path.resolve(tmpdir, entryFileHash + '.modules.cache.json');
+  return path.resolve(tmpdir, entryFileHash + '.modules.cache.json');
 }
 
 function getBundleCachePath(entryFileHash) {
-  path.resolve(tmpdir, entryFileHash + '.bundle.cache.js');
+  return path.resolve(tmpdir, entryFileHash + '.bundle.cache.js');
 }
 
 function isNotEmptyString(str) { return str !== '' }

--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ function clearCacheFiles(entryFileHash) {
   cachePaths.forEach(function(cachePath) {
     if (fs.existsSync(cachePath)) fs.unlinkSync(cachePath);
   })
-  console.log('[racer-bundle] Watchify cache cleared.');
+  console.log('[racer-bundle] Watchify cache cleared');
 }
 
 function getModuleCache(entryFileHash) {

--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ function bundle(entryFile, options, cb) {
 
   var entryFileHash = hashFilename(entryFile);
   var ignorePaths = addRealPaths(options.ignore || []);
-  var matchIgnorePaths = anymatch(ignorePaths);
   var minify = (options.minify == null) ? util.isProduction : options.minify;
 
   options.useCache = !!options.useCache || !!process.env.USE_CACHE
@@ -71,6 +70,7 @@ function wrapBundle(b, entryFileHash, ignorePaths, rebundle) {
   };
   watchify(b, watchifyOptions);
   // Rebundle whenever a file is changed unless explicitly ignored
+  var matchIgnorePaths = anymatch(ignorePaths);
   b.on('update', function(ids) {
     console.log('[racer-bundle] Files changed:', ids.toString());
     if (ids.every(matchIgnorePaths)) {

--- a/index.js
+++ b/index.js
@@ -45,13 +45,9 @@ function bundle(entryFile, options, cb) {
   var initialBundle = _callBundle.bind(null, cb)
   var rebundle = _callBundle.bind(null, options.onRebundle);
 
-  // Wrap browserify with caching/watching logic if requested
-  var useWatchify = options.onRebundle || options.useCache
-
   if (options.onRebundle) {
     wrapBundle(b, entryFileHash, ignorePaths, rebundle)
-  }
-  if (options.useCache) {
+  } else if (options.useCache) {
     wrapBundle(b, entryFileHash, ignorePaths)
   }
 

--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
-var fs = require('fs');
-var crypto = require('crypto');
-var browserify = require('browserify');
-var watchify = require('watchify-with-cache');
-var uglify = require('uglify-js');
-var convertSourceMap = require('convert-source-map');
 var anymatch = require('anymatch');
-var path = require('path');
+var browserify = require('browserify');
+var convertSourceMap = require('convert-source-map');
+var crypto = require('crypto');
+var fs = require('fs');
 var os = require('os');
-var util;
+var path = require('path');
 var tmpdir = os.tmpdir()
+var uglify = require('uglify-js');
+var util;
+var watchify = require('watchify-with-cache');
 
 module.exports = function(racer) {
   var Backend = racer.Backend || racer.Store;

--- a/index.js
+++ b/index.js
@@ -1,74 +1,116 @@
 var fs = require('fs');
+var crypto = require('crypto');
 var browserify = require('browserify');
-var watchify = require('watchify');
+var watchify = require('watchify-with-cache');
 var uglify = require('uglify-js');
 var convertSourceMap = require('convert-source-map');
 var anymatch = require('anymatch');
-
+var path = require('path');
+var os = require('os');
 var util;
+var tmpdir = os.tmpdir()
+
 module.exports = function(racer) {
   var Backend = racer.Backend || racer.Store;
   Backend.prototype.bundle = bundle;
   util = racer.util;
 };
 
-function bundle(file, options, cb) {
+function bundle(entryFile, options, cb) {
   if (typeof options === 'function') {
     cb = options;
     options = null;
   }
   options || (options = {});
   options.debug = true;
-  var minify = (options.minify == null) ? util.isProduction : options.minify;
-  // These objects need to be defined otherwise watchify disables its cache
-  options.cache = {};
   options.packageCache = {};
+  // The file paths in ignore should be ignored when monitoring for changes.
+  options.ignore = (options.ignore == null) ? [] : options.ignore
+  options.ignore.forEach(function(filepath) {
+    // NOTE: Chokidar provides the realpath's of files as their ids, so we
+    // have to add any realpath values that don't match the provided filepath's
+    // to our ignore array
+    var realpath = fs.realpathSync(filepath);
+    if (realpath !== filepath) options.ignore.push(realpath);
+  });
+
+  var minify = (options.minify == null) ? util.isProduction : options.minify;
+  options.fullPaths = (options.fullPaths == null) ? !util.isProduction : options.fullPaths;
+
+  // If useCache is defined, we use a persistent cache
+  var entryFileHash = hashFilename(entryFile);
+  var bundleCachePath, moduleCachePath;
+  // Allow env var flags to override options
+  var useCache = (process.env.CLEAR_CACHE == null) ? options.useCache : process.env.CLEAR_CACHE;
+  var clearCache = (process.env.USE_CACHE == null) ? options.useCache : process.env.USE_CACHE;
+  if (useCache) {
+    bundleCachePath = path.resolve(tmpdir,  entryFileHash + '.bundle.cache.js');
+    moduleCachePath = path.resolve(tmpdir, entryFileHash + '.modules.cache.json');
+    if (clearCache) {
+      console.log('[racer-bundle] Watchify cache cleared.')
+      fs.writeFileSync(moduleCachePath, '{}');
+    }
+    console.log('[racer-bundle] Loading watchify cache')
+    options.cache = watchify.getCache(moduleCachePath);
+  } else {
+    options.cache = {}
+  }
 
   var b = browserify(options);
+
+  // Echo log messages
+  b.on('log', function (msg) {
+    console.log(entryFile, 'log:', msg);
+  });
+
+  // Add the entryFile
+  b.add(entryFile);
   this.emit('bundle', b);
-  b.add(file);
 
-  // If onRebundle is defined, watch the bundle for changes
-  if (options.onRebundle) {
-    var w = watchify(b, {
+  // Wrap browserify with caching + watching logic if requested
+  if (options.onRebundle || options.useCache) {
+    b = watchify(b, {
       delay: 100,
+      cacheFile: moduleCachePath,
+      // The ignored paths should be checked by sha instead of mtime when deciding
+      // if they are invalid. This prevents regenerating the same view partials
+      // from causing a rebundle
+      checkShasum: options.ignore.slice(),
+      watch: !!options.onRebundle
     });
-
-    w.on('log', function (msg) {
-      console.log(file + ' bundled:', msg);
-    });
-
-    var ignore = (options.ignore == null) ? [] : options.ignore
-    // Chokidar/watchify provide the realpath's of files as their ids, so we
-    //  add any realpath values that don't match the provided filepath's.
-    ignore.forEach(function(filepath) {
-      var realpath = fs.realpathSync(filepath);
-      if (realpath !== filepath) ignore.push(realpath);
-    });
-    var matchIgnorePaths = anymatch(ignore)
-    // This gets fired every time a dependent file is changed
-    w.on('update', function(ids) {
-      console.log('Files changed:', ids.toString());
-      // If all the changed files are ignoreable, return before bundling
+    var matchIgnorePaths = anymatch(options.ignore)
+    // Rebundle whenever a file is changed unless explicitly ignored
+    b.on('update', function(ids) {
+      console.log('[racer-bundle] Files changed:', ids.toString());
       if (ids.every(matchIgnorePaths)) {
-        return console.log('Ignoring update')
+        return console.log('[racer-bundle] File explicitly Ignored. Skipping rebundle');
       }
-      callBundle(this, minify, options.onRebundle);
+      callBundle(this, bundleCachePath, minify, options.onRebundle);
     });
-
-    callBundle(w, minify, cb);
-  } else {
-    callBundle(b, minify, cb);
   }
+
+  callBundle(b, bundleCachePath, minify, cb);
 }
 
-function callBundle(b, minify, cb) {
+function callBundle(b, cachePath, minify, cb) {
+
+  function readOrSetCache(buffer) {
+    if (buffer) {
+      b.write()
+      fs.writeFileSync(cachePath, buffer)
+    } else {
+      buffer = fs.readFileSync(cachePath);
+    }
+    return buffer
+  }
+
   b.bundle(function(err, buffer) {
     if (err) return cb(err);
+    if (cachePath) buffer = readOrSetCache(buffer);
     // Extract the source map, which Browserify includes as a comment
     var source = buffer.toString('utf8');
-    var map = convertSourceMap.fromSource(source).toJSON();
-    source = convertSourceMap.removeComments(source);
+    var map = convertSourceMap.fromSource(source, true).toJSON();
+    source = removeSourceMapComments(source)
     if (!minify) return cb(null, source, map);
 
     // If inSourceMap is a string it is assumed to be a filename, but passing in
@@ -96,3 +138,18 @@ function callBundle(b, minify, cb) {
 }
 
 function isNotEmptyString(str) { return str !== '' }
+
+function removeSourceMapComments(content) {
+  var lines = content.split('\n');
+  var line;
+  // find all lines which contain a source map starting at end of content
+  for (var i = lines.length - 1; i > 0; i--) {
+    line = lines[i]
+    if (line.includes('sourceMappingURL=')) lines[i] = ''
+  }
+  return lines.join('\n')
+}
+
+function hashFilename(filename) {
+  return crypto.createHash('md5').update(filename).digest('hex');
+}

--- a/index.js
+++ b/index.js
@@ -155,14 +155,16 @@ function addRealPaths(filePaths) {
 }
 
 function clearCacheFiles(entryFileHash) {
-  fs.unlinkSync(getModuleCachePath(entryFileHash))
-  fs.unlinkSync(getModuleCachePath(entryFileHash))
-  console.log('[racer-bundle] Watchify cache cleared.')
+  var cachePaths = [getModuleCachePath(entryFileHash), getBundleCachePath(entryFileHash)];
+  cachePaths.forEach(function(cachePath) {
+    if (fs.existsSync(cachePath)) fs.unlinkSync(cachePath);
+  })
+  console.log('[racer-bundle] Watchify cache cleared.');
 }
 
 function getModuleCache(entryFileHash) {
-  console.log('[racer-bundle] Loading watchify cache')
-  return watchify.getCache(getModuleCachePath(entryFileHash))
+  console.log('[racer-bundle] Loading watchify cache');
+  return watchify.getCache(getModuleCachePath(entryFileHash));
 }
 
 function getModuleCachePath(entryFileHash) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "browserify": "^13.0.1",
     "convert-source-map": "^1.1.1",
     "uglify-js": "^2.4.24",
-    "watchify": "^3.4.0"
+    "watchify-with-cache": "^1.0.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
This PR: 
- Patches a potential stack overflow caused by a complex regex when used on large sourcemaps
- Leaves current functionality untouched
- Improve general code clarity and naming of variables
- Adds support for the `useCache` option
### useCache

If either `options.useCache` or `process.env.USE_CACHE` are defined, we persist browserify's internal module cache to disk after each successful bundle. The next time bundle is called, we then load that cache back into browserify. Each file is dirty-checked (using the files `mtime`) before being loaded into browserify's cache. 

_NOTE: the actual caching logic is handled by the separate `watchify-with-cache` module. I'm simply including a few details here for posterity._
### Clearing the cache

There are times where you might want to clear the cache. If the `process.env.CLEAR_CACHE` envar is defined, we clear the cache before the next bundle. Also, since the cache is stored within the user's `tmpdir`, it is subject to being cleared by the os itself (usually during a restart).
